### PR TITLE
Add animated tile updates to 2048 UI

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,22 +1,58 @@
-document.addEventListener('keydown', function(event) {
+const GRID_SIZE = 4;
+const MOVE_ANIMATION_DURATION = 180; // milliseconds
+const ANIMATION_BUFFER = 60;
+
+let tileContainer = null;
+let tilesState = new Map();
+let tileIdCounter = 0;
+let lastAction = null;
+let isAnimating = false;
+let cellPositions = [];
+let isWaitingForResponse = false;
+
+const KNOWN_TILE_CLASSES = new Set([
+    'tile-2', 'tile-4', 'tile-8', 'tile-16', 'tile-32', 'tile-64',
+    'tile-128', 'tile-256', 'tile-512', 'tile-1024', 'tile-2048', 'tile-super'
+]);
+
+document.addEventListener('DOMContentLoaded', () => {
+    tileContainer = document.querySelector('.tile-container');
+    cacheCellPositions();
+    window.addEventListener('resize', () => {
+        cacheCellPositions();
+        refreshTilePositions();
+    });
+    fetchInitialState();
+});
+
+document.addEventListener('keydown', (event) => {
+    if (isAnimating || isWaitingForResponse) {
+        return;
+    }
+
     let action = null;
     switch (event.key) {
-        case "ArrowUp":
+        case 'ArrowUp':
             action = 0;
             break;
-        case "ArrowRight":
+        case 'ArrowRight':
             action = 1;
             break;
-        case "ArrowDown":
+        case 'ArrowDown':
             action = 2;
             break;
-        case "ArrowLeft":
+        case 'ArrowLeft':
             action = 3;
             break;
         default:
-            return; // Exit if it's not an arrow key
+            return;
     }
-    
+
+    event.preventDefault();
+    lastAction = action;
+
+    isWaitingForResponse = true;
+
     fetch('/move', {
         method: 'POST',
         headers: {
@@ -24,95 +60,460 @@ document.addEventListener('keydown', function(event) {
         },
         body: JSON.stringify({ action: action }),
     })
-    .then(response => response.json())
-    .then(data => {
-        updateBoard(data.board, data.score, data.game_over);
-    })
-    .catch((error) => {
-        console.error('Error:', error);
-    });
-});
-
-// Function to fetch and update the board with the initial game state
-function fetchInitialState() {
-    fetch('/init')
-        .then(response => response.json())
-        .then(data => {
+        .then((response) => response.json())
+        .then((data) => {
+            isWaitingForResponse = false;
             updateBoard(data.board, data.score, data.game_over);
         })
         .catch((error) => {
             console.error('Error:', error);
+            isWaitingForResponse = false;
+        });
+});
+
+function fetchInitialState() {
+    lastAction = null;
+    isWaitingForResponse = true;
+    fetch('/init')
+        .then((response) => response.json())
+        .then((data) => {
+            isWaitingForResponse = false;
+            updateBoard(data.board, data.score, data.game_over);
+        })
+        .catch((error) => {
+            console.error('Error:', error);
+            isWaitingForResponse = false;
         });
 }
 
-// Call fetchInitialState when the window loads
-window.onload = function() {
-    fetchInitialState();
-};
+function updateBoard(board, score, gameOver) {
+    updateScore(score);
 
-function updateBoard(board, score, game_over) {
-    const cells = document.querySelectorAll('.grid-cell');
-    for (let i = 0; i < cells.length; i++) {
-        const row = Math.floor(i / 4);
-        const col = i % 4;
-        const value = board[row][col];
-        const cell = cells[i];
-
-        // Clear previous classes
-        cell.className = 'grid-cell';
-        cell.textContent = value === 0 ? '' : value;
-
-        // Add color based on the cell's value
-        if (value === 2) cell.classList.add('tile-2');
-        else if (value === 4) cell.classList.add('tile-4');
-        else if (value === 8) cell.classList.add('tile-8');
-        else if (value === 16) cell.classList.add('tile-16');
-        else if (value === 32) cell.classList.add('tile-32');
-        else if (value === 64) cell.classList.add('tile-64');
-        else if (value > 64) cell.classList.add('tile-super');
+    const canAnimate = lastAction !== null && tilesState.size > 0;
+    if (canAnimate) {
+        const simulation = simulateMove(lastAction, board);
+        if (simulation && (simulation.moved || simulation.spawnTiles.length > 0)) {
+            tileIdCounter = simulation.nextId;
+            playAnimation(simulation, board, gameOver);
+        } else {
+            renderBoardInstant(board);
+            updateGameState(gameOver);
+        }
+    } else {
+        renderBoardInstant(board);
+        updateGameState(gameOver);
     }
-    updateScore(score)
-    updateGameState(game_over)
+
+    lastAction = null;
 }
 
-function newGame() {
-    fetch('/init', {
-        method: 'GET'
-    })
-    .then(response => response.json())
-    .then(data => {
-        updateBoard(data.board, data.score, data.game_over);
-    })
-    .catch(error => {
-        console.error('Error:', error);
+function renderBoardInstant(board) {
+    if (!tileContainer) {
+        return;
+    }
+
+    if (!cellPositions.length) {
+        cacheCellPositions();
+    }
+
+    tileContainer.innerHTML = '';
+    tilesState.clear();
+
+    for (let row = 0; row < GRID_SIZE; row++) {
+        for (let col = 0; col < GRID_SIZE; col++) {
+            const value = board[row][col];
+            if (value === 0) {
+                continue;
+            }
+            const tileState = createTileState(value, row, col);
+            tileContainer.appendChild(tileState.element);
+            tilesState.set(tileState.id, tileState);
+        }
+    }
+
+    isAnimating = false;
+}
+
+function playAnimation(simulation, finalBoard, gameOver) {
+    const { moves, resultTiles, spawnTiles, removedTiles } = simulation;
+    isAnimating = true;
+
+    moves.forEach((move) => {
+        const tileState = tilesState.get(move.id);
+        if (!tileState) {
+            return;
+        }
+        tileState.row = move.toRow;
+        tileState.col = move.toCol;
+        requestAnimationFrame(() => {
+            setTilePosition(tileState.element, move.toRow, move.toCol);
+        });
     });
+
+    const cleanupDelay = MOVE_ANIMATION_DURATION + ANIMATION_BUFFER;
+
+    setTimeout(() => {
+        removedTiles.forEach((id) => {
+            const tileState = tilesState.get(id);
+            if (tileState) {
+                tileState.element.remove();
+                tilesState.delete(id);
+            }
+        });
+
+        resultTiles.forEach((tile) => {
+            if (tilesState.has(tile.id)) {
+                const tileState = tilesState.get(tile.id);
+                tileState.value = tile.value;
+                tileState.row = tile.row;
+                tileState.col = tile.col;
+                tileState.element.textContent = tile.value;
+                updateTileClasses(tileState.element, tile.value);
+                setTilePosition(tileState.element, tile.row, tile.col);
+            } else {
+                const tileState = createTileState(tile.value, tile.row, tile.col, tile.id);
+                tileState.element.classList.add('tile-merged');
+                tileContainer.appendChild(tileState.element);
+                tilesState.set(tile.id, tileState);
+            }
+        });
+
+        spawnTiles.forEach((tile) => {
+            const tileState = createTileState(tile.value, tile.row, tile.col, tile.id);
+            tileState.element.classList.add('tile-new');
+            tileContainer.appendChild(tileState.element);
+            tilesState.set(tile.id, tileState);
+        });
+
+        ensureBoardIntegrity(finalBoard);
+        updateGameState(gameOver);
+        isAnimating = false;
+    }, cleanupDelay);
+}
+
+function simulateMove(action, finalBoard) {
+    if (action === null) {
+        return null;
+    }
+
+    const board = Array.from({ length: GRID_SIZE }, () => Array(GRID_SIZE).fill(null));
+    tilesState.forEach((tile) => {
+        board[tile.row][tile.col] = {
+            id: tile.id,
+            value: tile.value,
+            row: tile.row,
+            col: tile.col,
+        };
+    });
+
+    let moved = false;
+    let tempNextId = tileIdCounter;
+    const moves = [];
+    const resultTiles = [];
+    const removedTiles = new Set();
+
+    const processMerge = (first, second, targetRow, targetCol) => {
+        const newId = tempNextId++;
+        moves.push({ id: first.id, toRow: targetRow, toCol: targetCol, mergeInto: newId });
+        moves.push({ id: second.id, toRow: targetRow, toCol: targetCol, mergeInto: newId });
+        resultTiles.push({ id: newId, value: first.value * 2, row: targetRow, col: targetCol, isMergeResult: true });
+        removedTiles.add(first.id);
+        removedTiles.add(second.id);
+        if (first.row !== targetRow || first.col !== targetCol) {
+            moved = true;
+        }
+        if (second.row !== targetRow || second.col !== targetCol) {
+            moved = true;
+        }
+        moved = true;
+    };
+
+    const processMove = (tile, targetRow, targetCol) => {
+        moves.push({ id: tile.id, toRow: targetRow, toCol: targetCol, mergeInto: null });
+        resultTiles.push({ id: tile.id, value: tile.value, row: targetRow, col: targetCol, isMergeResult: false });
+        if (tile.row !== targetRow || tile.col !== targetCol) {
+            moved = true;
+        }
+    };
+
+    switch (action) {
+        case 0: // Up
+            for (let col = 0; col < GRID_SIZE; col++) {
+                const line = [];
+                for (let row = 0; row < GRID_SIZE; row++) {
+                    const cell = board[row][col];
+                    if (cell) {
+                        line.push({ ...cell });
+                    }
+                }
+                let targetRow = 0;
+                while (line.length) {
+                    const current = line.shift();
+                    if (line.length && line[0].value === current.value) {
+                        const next = line.shift();
+                        processMerge(current, next, targetRow, col);
+                    } else {
+                        processMove(current, targetRow, col);
+                    }
+                    targetRow++;
+                }
+            }
+            break;
+        case 1: // Right
+            for (let row = 0; row < GRID_SIZE; row++) {
+                const line = [];
+                for (let col = GRID_SIZE - 1; col >= 0; col--) {
+                    const cell = board[row][col];
+                    if (cell) {
+                        line.push({ ...cell });
+                    }
+                }
+                let targetCol = GRID_SIZE - 1;
+                while (line.length) {
+                    const current = line.shift();
+                    if (line.length && line[0].value === current.value) {
+                        const next = line.shift();
+                        processMerge(current, next, row, targetCol);
+                    } else {
+                        processMove(current, row, targetCol);
+                    }
+                    targetCol--;
+                }
+            }
+            break;
+        case 2: // Down
+            for (let col = 0; col < GRID_SIZE; col++) {
+                const line = [];
+                for (let row = GRID_SIZE - 1; row >= 0; row--) {
+                    const cell = board[row][col];
+                    if (cell) {
+                        line.push({ ...cell });
+                    }
+                }
+                let targetRow = GRID_SIZE - 1;
+                while (line.length) {
+                    const current = line.shift();
+                    if (line.length && line[0].value === current.value) {
+                        const next = line.shift();
+                        processMerge(current, next, targetRow, col);
+                    } else {
+                        processMove(current, targetRow, col);
+                    }
+                    targetRow--;
+                }
+            }
+            break;
+        case 3: // Left
+            for (let row = 0; row < GRID_SIZE; row++) {
+                const line = [];
+                for (let col = 0; col < GRID_SIZE; col++) {
+                    const cell = board[row][col];
+                    if (cell) {
+                        line.push({ ...cell });
+                    }
+                }
+                let targetCol = 0;
+                while (line.length) {
+                    const current = line.shift();
+                    if (line.length && line[0].value === current.value) {
+                        const next = line.shift();
+                        processMerge(current, next, row, targetCol);
+                    } else {
+                        processMove(current, row, targetCol);
+                    }
+                    targetCol++;
+                }
+            }
+            break;
+        default:
+            return null;
+    }
+
+    const resultBoard = Array.from({ length: GRID_SIZE }, () => Array(GRID_SIZE).fill(0));
+    resultTiles.forEach((tile) => {
+        resultBoard[tile.row][tile.col] = tile.value;
+    });
+
+    const spawnTiles = [];
+    let mismatch = false;
+
+    outer: for (let row = 0; row < GRID_SIZE; row++) {
+        for (let col = 0; col < GRID_SIZE; col++) {
+            const finalValue = finalBoard[row][col];
+            const simulatedValue = resultBoard[row][col];
+            if (finalValue !== simulatedValue) {
+                if (simulatedValue === 0 && finalValue > 0) {
+                    const newId = tempNextId++;
+                    spawnTiles.push({ id: newId, value: finalValue, row, col });
+                    resultBoard[row][col] = finalValue;
+                } else {
+                    mismatch = true;
+                    break outer;
+                }
+            }
+        }
+    }
+
+    if (mismatch) {
+        return null;
+    }
+
+    if (!boardsEqual(resultBoard, finalBoard)) {
+        return null;
+    }
+
+    return {
+        moves,
+        resultTiles,
+        spawnTiles,
+        removedTiles,
+        moved: moved || spawnTiles.length > 0,
+        nextId: tempNextId,
+    };
+}
+
+function cacheCellPositions() {
+    if (!tileContainer) {
+        return;
+    }
+
+    const containerRect = tileContainer.getBoundingClientRect();
+    const rows = Array.from(document.querySelectorAll('.grid-row'));
+    cellPositions = rows.map((rowEl) => {
+        const cells = Array.from(rowEl.querySelectorAll('.grid-cell'));
+        return cells.map((cellEl) => {
+            const rect = cellEl.getBoundingClientRect();
+            return {
+                x: rect.left - containerRect.left,
+                y: rect.top - containerRect.top,
+                size: rect.width,
+            };
+        });
+    });
+
+    if (cellPositions[0] && cellPositions[0][0]) {
+        tileContainer.style.setProperty('--tile-size', `${cellPositions[0][0].size}px`);
+    }
+}
+
+function refreshTilePositions() {
+    tilesState.forEach((tile) => {
+        setTilePosition(tile.element, tile.row, tile.col);
+    });
+}
+
+function setTilePosition(element, row, col) {
+    if (!cellPositions[row] || !cellPositions[row][col]) {
+        cacheCellPositions();
+    }
+
+    const position = cellPositions[row][col];
+    element.style.setProperty('--x', `${position.x}px`);
+    element.style.setProperty('--y', `${position.y}px`);
+}
+
+function createTileState(value, row, col, id = null) {
+    const tileId = id !== null ? id : getNextTileId();
+    const element = buildTileElement(tileId, value, row, col);
+    return { id: tileId, value, row, col, element };
+}
+
+function buildTileElement(tileId, value, row, col) {
+    const element = document.createElement('div');
+    element.classList.add('tile');
+    element.dataset.id = tileId;
+    element.textContent = value;
+    updateTileClasses(element, value);
+    setTilePosition(element, row, col);
+    element.addEventListener('animationend', () => {
+        element.classList.remove('tile-new');
+        element.classList.remove('tile-merged');
+    });
+    return element;
+}
+
+function updateTileClasses(element, value) {
+    KNOWN_TILE_CLASSES.forEach((cls) => {
+        element.classList.remove(cls);
+    });
+
+    const className = KNOWN_TILE_CLASSES.has(`tile-${value}`) ? `tile-${value}` : 'tile-super';
+    element.classList.add(className);
+}
+
+function getNextTileId() {
+    const id = tileIdCounter;
+    tileIdCounter += 1;
+    return id;
 }
 
 function updateScore(score) {
     document.getElementById('current-score').textContent = score;
 }
 
-
-function updateGameState(game_over) {
+function updateGameState(gameOver) {
     const gameContainer = document.getElementById('game-container');
-    
-    // Clear any existing overlay first
     const existingOverlay = document.querySelector('.game-over-overlay');
     if (existingOverlay) {
         existingOverlay.remove();
     }
 
-    if (game_over) {
-        // Create the game over overlay
+    if (gameOver) {
         const overlay = document.createElement('div');
         overlay.className = 'game-over-overlay';
         overlay.innerHTML = `
             <span>Game Over!</span>
             <button class="new-game-button" onclick="newGame()">Try again</button>
         `;
-
-        // Append the overlay to the game container
         gameContainer.appendChild(overlay);
     }
 }
-    
+
+function ensureBoardIntegrity(targetBoard) {
+    const currentBoard = getCurrentBoard();
+    if (!boardsEqual(currentBoard, targetBoard)) {
+        console.warn('Board mismatch detected, re-rendering.');
+        renderBoardInstant(targetBoard);
+    }
+}
+
+function getCurrentBoard() {
+    const board = Array.from({ length: GRID_SIZE }, () => Array(GRID_SIZE).fill(0));
+    tilesState.forEach((tile) => {
+        board[tile.row][tile.col] = tile.value;
+    });
+    return board;
+}
+
+function boardsEqual(boardA, boardB) {
+    for (let row = 0; row < GRID_SIZE; row++) {
+        for (let col = 0; col < GRID_SIZE; col++) {
+            if (boardA[row][col] !== boardB[row][col]) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+function newGame() {
+    if (isAnimating || isWaitingForResponse) {
+        return;
+    }
+
+    lastAction = null;
+    isAnimating = false;
+    isWaitingForResponse = true;
+    fetch('/init', {
+        method: 'GET',
+    })
+        .then((response) => response.json())
+        .then((data) => {
+            isWaitingForResponse = false;
+            updateBoard(data.board, data.score, data.game_over);
+        })
+        .catch((error) => {
+            console.error('Error:', error);
+            isWaitingForResponse = false;
+        });
+}

--- a/static/style.css
+++ b/static/style.css
@@ -44,10 +44,13 @@ body {
 
 #game-container {
     text-align: center;
+    position: relative;
+    display: inline-block;
 }
 
 .grid {
     display: inline-block;
+    position: relative;
     background-color: #bbada0;
     padding: 10px;
     border-radius: 10px;
@@ -59,40 +62,141 @@ body {
 }
 
 .grid-cell {
-    width: 90px; /* Adjust the size as necessary */
-    height: 90px; /* Adjust the size as necessary */
-    background-color: #cdc1b4;
+    width: 90px;
+    height: 90px;
     margin: 5px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-size: 24px;
-    font-weight: bold;
-    color: #776e65;
     border-radius: 5px;
-    position: relative; /* Make sure this is relative */
-    overflow: hidden; /* Prevents content from spilling outside */
+    background: rgba(238, 228, 218, 0.35);
 }
 
-/* Styles for sliding tiles */
+.tile-container {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 2;
+    --tile-size: 90px;
+}
+
 .tile {
     position: absolute;
-    width: 100%;
-    height: 100%;
+    width: var(--tile-size);
+    height: var(--tile-size);
     display: flex;
-    justify-content: center;
     align-items: center;
-    transition: transform 0.2s ease; /* Sliding effect */
+    justify-content: center;
+    font-weight: bold;
+    font-size: 32px;
+    border-radius: 5px;
+    transform: translate(var(--x, 0px), var(--y, 0px));
+    transition: transform 0.18s ease-in-out;
+    will-change: transform;
+    box-shadow: 0 6px 10px rgba(0, 0, 0, 0.15);
+    z-index: 2;
 }
 
-/* New styles for tile colors */
-.tile-2 { background-color: #eee4da; }
-.tile-4 { background-color: #ede0c8; }
-.tile-8 { background-color: #f2b179; }
-.tile-16 { background-color: #f59563; }
-.tile-32 { background-color: #f67c5f; }
-.tile-64 { background-color: #f65e3b; }
-.tile-super { background-color: #edcf72; }
+.tile.tile-128,
+.tile.tile-256,
+.tile.tile-512 {
+    font-size: 28px;
+}
+
+.tile.tile-1024,
+.tile.tile-2048,
+.tile.tile-super {
+    font-size: 24px;
+}
+
+.tile-new {
+    animation: tileAppear 0.2s ease;
+}
+
+.tile-merged {
+    animation: tileMerge 0.25s ease;
+}
+
+@keyframes tileAppear {
+    from {
+        transform: translate(var(--x, 0px), var(--y, 0px)) scale(0.3);
+        opacity: 0;
+    }
+    to {
+        transform: translate(var(--x, 0px), var(--y, 0px)) scale(1);
+        opacity: 1;
+    }
+}
+
+@keyframes tileMerge {
+    0% {
+        transform: translate(var(--x, 0px), var(--y, 0px)) scale(0.85);
+    }
+    60% {
+        transform: translate(var(--x, 0px), var(--y, 0px)) scale(1.05);
+    }
+    100% {
+        transform: translate(var(--x, 0px), var(--y, 0px)) scale(1);
+    }
+}
+
+/* Tile colors */
+.tile.tile-2 {
+    background-color: #eee4da;
+    color: #776e65;
+}
+
+.tile.tile-4 {
+    background-color: #ede0c8;
+    color: #776e65;
+}
+
+.tile.tile-8 {
+    background-color: #f2b179;
+    color: #f9f6f2;
+}
+
+.tile.tile-16 {
+    background-color: #f59563;
+    color: #f9f6f2;
+}
+
+.tile.tile-32 {
+    background-color: #f67c5f;
+    color: #f9f6f2;
+}
+
+.tile.tile-64 {
+    background-color: #f65e3b;
+    color: #f9f6f2;
+}
+
+.tile.tile-128 {
+    background-color: #edcf72;
+    color: #f9f6f2;
+}
+
+.tile.tile-256 {
+    background-color: #edcc61;
+    color: #f9f6f2;
+}
+
+.tile.tile-512 {
+    background-color: #edc850;
+    color: #f9f6f2;
+}
+
+.tile.tile-1024 {
+    background-color: #edc53f;
+    color: #f9f6f2;
+}
+
+.tile.tile-2048 {
+    background-color: #edc22e;
+    color: #f9f6f2;
+}
+
+.tile.tile-super {
+    background-color: #3c3a32;
+    color: #f9f6f2;
+}
 
 
 .game-over-overlay {
@@ -110,6 +214,7 @@ body {
     font-size: 36px;
     color: #776e65;
     animation: fadeIn 0.5s;
+    z-index: 3;
 }
 
 @keyframes fadeIn {

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,7 @@
         </div>
         <div id="game-container">
             <div class="grid">
+                <div class="tile-container"></div>
                 <!-- Generate grid cells -->
                 <div class="grid-row">
                     <div class="grid-cell"></div>


### PR DESCRIPTION
## Summary
- add a floating tile layer in the board template to support animated tile movement
- restyle the board to support sliding, merge, and spawn animations with new CSS transitions
- rework the frontend logic to simulate moves, animate tiles, and coordinate merge/spawn effects smoothly

## Testing
- python -m compileall app.py game2048.py

------
https://chatgpt.com/codex/tasks/task_e_68d1d00192a483268be144370d0cb7dc